### PR TITLE
Fix: Refactor load_users_for_member_email to use load_combobox_async

### DIFF
--- a/gui/groups_window.py
+++ b/gui/groups_window.py
@@ -1159,14 +1159,6 @@ class GroupsWindow(BaseOperationWindow):
 
     def load_users_for_member_email(self):
         """Load users for member email combobox in Manage Members."""
-        def fetch_and_populate():
-            from utils.workspace_data import fetch_users
-            users = fetch_users()
-            if users:
-                sorted_users = sorted(users)
-                self.after(0, lambda: self.manage_members_email.configure(values=sorted_users))
-                self.after(0, lambda: self.enable_standalone_fuzzy_search(self.manage_members_email, sorted_users))
-
-        import threading
-        threading.Thread(target=fetch_and_populate, daemon=True).start()
+        from utils.workspace_data import fetch_users
+        self.load_combobox_async(self.manage_members_email, fetch_users, enable_fuzzy=True)
 


### PR DESCRIPTION
Fixed AttributeError when opening Group Management window.

The load_users_for_member_email method was still calling the removed enable_standalone_fuzzy_search method. Refactored to use the new load_combobox_async method for consistency with all other load methods.

This completes the refactoring of all combobox loading methods in groups_window.py.