### PR TITLE
Refactor: Complete calendar window redesign to match project patterns

### DIFF
--- a/gui/calendar_window.py
+++ b/gui/calendar_window.py
@@ -1,17 +1,15 @@
 """
-Calendar Operations window for GAM Admin Tool.
+Calendar Operations Window for GAM Admin Tool.
 
-Provides GUI for calendar operations including:
-- Managing calendar permissions (sharing)
-- Creating and deleting calendars
-- Viewing calendar information and URLs
-- Importing and exporting calendar data
+Provides a tabbed interface for all calendar-related operations including
+managing permissions, creating/deleting calendars, viewing information,
+and importing/exporting calendar data.
+
+Inherits from BaseOperationWindow for common functionality.
 """
 
 import tkinter as tk
-from tkinter import ttk, messagebox, filedialog, scrolledtext
-import threading
-import queue
+from tkinter import ttk, messagebox, filedialog
 import os
 from datetime import datetime, timedelta
 
@@ -20,11 +18,32 @@ from modules import calendar as calendar_ops
 from utils.workspace_data import fetch_users, fetch_groups
 
 
+# Calendar color mapping (GAM color IDs to names)
+CALENDAR_COLORS = {
+    "": "Default",
+    "1": "Lavender",
+    "2": "Sage",
+    "3": "Grape",
+    "4": "Flamingo",
+    "5": "Banana",
+    "6": "Tangerine",
+    "7": "Peacock",
+    "8": "Graphite",
+    "9": "Blueberry",
+    "10": "Basil",
+    "11": "Tomato"
+}
+
+
 class CalendarWindow(BaseOperationWindow):
     """
-    Calendar Operations window.
+    Calendar Operations window with tabbed interface.
 
-    Inherits from BaseOperationWindow to provide consistent UI and functionality.
+    Provides 4 tabs for different calendar operations:
+    - Manage Permissions
+    - Create/Delete Calendars
+    - View Calendar Info
+    - Import/Export Data
     """
 
     def __init__(self, parent):
@@ -34,36 +53,51 @@ class CalendarWindow(BaseOperationWindow):
         Args:
             parent: The parent tkinter widget
         """
-        super().__init__(parent, "Calendar Operations", window_size="1000x800")
+        super().__init__(parent, "Calendar Operations", "900x750", (800, 600))
 
     def create_operation_tabs(self):
-        """Create tabs for calendar operations."""
-        # Tab 1: Manage Calendar Permissions
+        """Create all calendar operation tabs."""
         self.create_permissions_tab()
+        self.create_manage_calendars_tab()
+        self.create_view_info_tab()
+        self.create_import_export_tab()
+
+        # Auto-load comboboxes on window initialization
+        self.after(100, self.initialize_comboboxes)
+
+    def initialize_comboboxes(self):
+        """Auto-load all comboboxes on window initialization."""
+        # Tab 1: Manage Permissions
+        self.load_combobox_async(self.permissions_owner_combo, fetch_users, enable_fuzzy=True)
+        self.load_combobox_async(self.permissions_user_combo, fetch_users, enable_fuzzy=True)
 
         # Tab 2: Create/Delete Calendars
-        self.create_manage_calendars_tab()
+        self.load_combobox_async(self.manage_calendar_owner_combo, fetch_users, enable_fuzzy=True)
 
-        # Tab 3: View Calendar Information
-        self.create_view_info_tab()
+        # Tab 3: View Info
+        self.load_combobox_async(self.view_info_owner_combo, fetch_users, enable_fuzzy=True)
 
-        # Tab 4: Import/Export Calendar Data
-        self.create_import_export_tab()
+        # Tab 4: Import/Export
+        self.load_combobox_async(self.import_export_owner_combo, fetch_users, enable_fuzzy=True)
 
     # ==================== TAB 1: MANAGE PERMISSIONS ====================
 
     def create_permissions_tab(self):
         """Create tab for managing calendar permissions."""
-        tab = ttk.Frame(self.notebook)
+        tab = ttk.Frame(self.notebook, padding="10")
         self.notebook.add(tab, text="Manage Permissions")
 
-        # Create scrollable container
-        container, scrollable = self.create_scrollable_frame(tab)
-        container.pack(fill=tk.BOTH, expand=True)
+        # Instructions
+        instructions = ttk.Label(
+            tab,
+            text="Share or unshare calendars with users/groups. Choose permission level and optionally send notifications.",
+            wraplength=800
+        )
+        instructions.pack(pady=(0, 10), anchor=tk.W)
 
         # Operation type (Add or Remove)
-        operation_frame = ttk.LabelFrame(scrollable, text="Operation", padding="10")
-        operation_frame.pack(fill=tk.X, padx=10, pady=5)
+        operation_frame = ttk.LabelFrame(tab, text="Operation", padding="10")
+        operation_frame.pack(fill=tk.X, pady=(0, 10))
 
         self.permissions_operation_var = tk.StringVar(value="add")
         ttk.Radiobutton(
@@ -83,26 +117,19 @@ class CalendarWindow(BaseOperationWindow):
         ).pack(side=tk.LEFT)
 
         # Calendar Selection Frame
-        calendar_frame = ttk.LabelFrame(scrollable, text="Calendar Selection", padding="10")
-        calendar_frame.pack(fill=tk.X, padx=10, pady=5)
+        calendar_frame = ttk.LabelFrame(tab, text="Calendar Selection", padding="10")
+        calendar_frame.pack(fill=tk.X, pady=(0, 10))
 
-        # User email (calendar owner)
+        # Calendar Owner
         row = 0
         ttk.Label(calendar_frame, text="Calendar Owner:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
         self.permissions_owner_combo = ttk.Combobox(calendar_frame, width=40)
         self.permissions_owner_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
         calendar_frame.columnconfigure(1, weight=1)
 
-        # Load users button
-        ttk.Button(
-            calendar_frame,
-            text="Load Users",
-            command=self.load_users_for_permissions_owner
-        ).grid(row=row, column=2, padx=5, pady=5)
-
-        # Calendar ID or dropdown
+        # Calendar ID
         row += 1
-        ttk.Label(calendar_frame, text="Calendar ID:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
+        ttk.Label(calendar_frame, text="Calendar Name:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
         self.permissions_calendar_combo = ttk.Combobox(calendar_frame, width=40)
         self.permissions_calendar_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
 
@@ -120,8 +147,8 @@ class CalendarWindow(BaseOperationWindow):
         ).grid(row=row+1, column=0, columnspan=3, sticky=tk.W, padx=5, pady=(0, 5))
 
         # User/Group to share with
-        permission_user_frame = ttk.LabelFrame(scrollable, text="Share With", padding="10")
-        permission_user_frame.pack(fill=tk.X, padx=10, pady=5)
+        permission_user_frame = ttk.LabelFrame(tab, text="Share With", padding="10")
+        permission_user_frame.pack(fill=tk.X, pady=(0, 10))
 
         row = 0
         ttk.Label(permission_user_frame, text="User/Group Email:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
@@ -129,15 +156,9 @@ class CalendarWindow(BaseOperationWindow):
         self.permissions_user_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
         permission_user_frame.columnconfigure(1, weight=1)
 
-        ttk.Button(
-            permission_user_frame,
-            text="Load Users",
-            command=self.load_users_for_permissions_target
-        ).grid(row=row, column=2, padx=5, pady=5)
-
         # Permission Settings Frame (only for Add operation)
-        self.permissions_settings_frame = ttk.LabelFrame(scrollable, text="Permission Settings", padding="10")
-        self.permissions_settings_frame.pack(fill=tk.X, padx=10, pady=5)
+        self.permissions_settings_frame = ttk.LabelFrame(tab, text="Permission Settings", padding="10")
+        self.permissions_settings_frame.pack(fill=tk.X, pady=(0, 10))
 
         row = 0
         ttk.Label(self.permissions_settings_frame, text="Permission Level:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
@@ -176,34 +197,27 @@ class CalendarWindow(BaseOperationWindow):
             foreground='orange'
         ).grid(row=row+1, column=0, columnspan=2, sticky=tk.W, padx=5, pady=(0, 5))
 
+        # Progress frame
+        self.permissions_progress_frame = self.create_progress_frame(tab)
+        self.permissions_progress_frame.pack(fill=tk.BOTH, expand=True, pady=(10, 0))
+
         # Execute button
-        execute_frame = ttk.Frame(scrollable)
-        execute_frame.pack(fill=tk.X, padx=10, pady=10)
+        execute_frame = ttk.Frame(tab)
+        execute_frame.pack(fill=tk.X, pady=(10, 0))
 
         ttk.Button(
             execute_frame,
             text="Execute",
             command=self.execute_permissions_operation,
             width=20
-        ).pack(side=tk.LEFT, padx=5)
-
-        # Progress frame
-        self.permissions_progress_frame = self.create_progress_frame(scrollable)
+        ).pack(side=tk.LEFT)
 
     def toggle_permissions_operation(self):
         """Toggle visibility of permission settings based on operation."""
         if self.permissions_operation_var.get() == "add":
-            self.permissions_settings_frame.pack(fill=tk.X, padx=10, pady=5)
+            self.permissions_settings_frame.pack(fill=tk.X, pady=(0, 10))
         else:
             self.permissions_settings_frame.pack_forget()
-
-    def load_users_for_permissions_owner(self):
-        """Load users for calendar owner combobox."""
-        self.load_combobox_async(self.permissions_owner_combo, fetch_users, enable_fuzzy=True)
-
-    def load_users_for_permissions_target(self):
-        """Load users for target user combobox."""
-        self.load_combobox_async(self.permissions_user_combo, fetch_users, enable_fuzzy=True)
 
     def load_calendars_for_permissions(self):
         """Load calendars for selected owner."""
@@ -214,7 +228,6 @@ class CalendarWindow(BaseOperationWindow):
 
         def fetch_calendars():
             calendars = calendar_ops.get_user_calendars(owner_email)
-            # Format as "Summary (ID)"
             return [f"{cal['summary']} ({cal['id']})" for cal in calendars]
 
         self.load_combobox_async(self.permissions_calendar_combo, fetch_calendars, enable_fuzzy=True)
@@ -232,7 +245,7 @@ class CalendarWindow(BaseOperationWindow):
             messagebox.showerror("Error", "Please enter calendar owner email")
             return
         if not calendar_input:
-            messagebox.showerror("Error", "Please enter calendar ID")
+            messagebox.showerror("Error", "Please enter calendar name")
             return
         if not target_user:
             messagebox.showerror("Error", "Please enter user/group email to share with")
@@ -279,16 +292,20 @@ class CalendarWindow(BaseOperationWindow):
 
     def create_manage_calendars_tab(self):
         """Create tab for creating/deleting calendars."""
-        tab = ttk.Frame(self.notebook)
+        tab = ttk.Frame(self.notebook, padding="10")
         self.notebook.add(tab, text="Create/Delete Calendars")
 
-        # Create scrollable container
-        container, scrollable = self.create_scrollable_frame(tab)
-        container.pack(fill=tk.BOTH, expand=True)
+        # Instructions
+        instructions = ttk.Label(
+            tab,
+            text="Create new calendars or delete existing ones.",
+            wraplength=800
+        )
+        instructions.pack(pady=(0, 10), anchor=tk.W)
 
         # Operation type
-        operation_frame = ttk.LabelFrame(scrollable, text="Operation", padding="10")
-        operation_frame.pack(fill=tk.X, padx=10, pady=5)
+        operation_frame = ttk.LabelFrame(tab, text="Operation", padding="10")
+        operation_frame.pack(fill=tk.X, pady=(0, 10))
 
         self.manage_calendar_operation_var = tk.StringVar(value="create")
         ttk.Radiobutton(
@@ -307,107 +324,90 @@ class CalendarWindow(BaseOperationWindow):
             command=self.toggle_manage_calendar_operation
         ).pack(side=tk.LEFT)
 
-        # Create Calendar Frame
-        self.create_calendar_frame = ttk.LabelFrame(scrollable, text="Create New Calendar", padding="10")
-        self.create_calendar_frame.pack(fill=tk.X, padx=10, pady=5)
+        # Shared Calendar Details Frame
+        details_frame = ttk.LabelFrame(tab, text="Calendar Details", padding="10")
+        details_frame.pack(fill=tk.X, pady=(0, 10))
 
+        # Calendar Owner (shared)
         row = 0
-        ttk.Label(self.create_calendar_frame, text="Calendar Owner:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
-        self.create_calendar_owner_combo = ttk.Combobox(self.create_calendar_frame, width=40)
-        self.create_calendar_owner_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
+        ttk.Label(details_frame, text="Calendar Owner:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
+        self.manage_calendar_owner_combo = ttk.Combobox(details_frame, width=40)
+        self.manage_calendar_owner_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
+        details_frame.columnconfigure(1, weight=1)
+
+        # Bind owner selection to load calendars
+        self.manage_calendar_owner_combo.bind('<<ComboboxSelected>>', lambda e: self.load_calendars_for_manage())
+
+        # Calendar Name (shared)
+        row += 1
+        ttk.Label(details_frame, text="Calendar Name:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
+        self.manage_calendar_name_combo = ttk.Combobox(details_frame, width=40)
+        self.manage_calendar_name_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
+
+        # Load button (for delete mode)
+        self.manage_calendar_load_btn = ttk.Button(
+            details_frame,
+            text="Load Calendars",
+            command=self.load_calendars_for_manage
+        )
+        self.manage_calendar_load_btn.grid(row=row, column=2, padx=5, pady=5)
+
+        # Create-specific fields frame
+        self.create_calendar_frame = ttk.Frame(details_frame)
+        self.create_calendar_frame.grid(row=3, column=0, columnspan=3, sticky=tk.EW, pady=(10, 0))
+
+        # Description (create only)
+        ttk.Label(self.create_calendar_frame, text="Description:").grid(row=0, column=0, sticky=tk.W, padx=5, pady=5)
+        self.create_calendar_desc_entry = ttk.Entry(self.create_calendar_frame, width=40)
+        self.create_calendar_desc_entry.grid(row=0, column=1, sticky=tk.EW, padx=5, pady=5)
         self.create_calendar_frame.columnconfigure(1, weight=1)
 
-        ttk.Button(
-            self.create_calendar_frame,
-            text="Load Users",
-            command=self.load_users_for_create_calendar
-        ).grid(row=row, column=2, padx=5, pady=5)
-
-        row += 1
-        ttk.Label(self.create_calendar_frame, text="Calendar Name:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
-        self.create_calendar_name_entry = ttk.Entry(self.create_calendar_frame, width=40)
-        self.create_calendar_name_entry.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
-
-        row += 1
-        ttk.Label(self.create_calendar_frame, text="Description:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
-        self.create_calendar_desc_entry = ttk.Entry(self.create_calendar_frame, width=40)
-        self.create_calendar_desc_entry.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
-
-        row += 1
-        ttk.Label(self.create_calendar_frame, text="Color (optional):").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
+        # Color (create only)
+        ttk.Label(self.create_calendar_frame, text="Color:").grid(row=1, column=0, sticky=tk.W, padx=5, pady=5)
         self.create_calendar_color_var = tk.StringVar(value="")
         color_combo = ttk.Combobox(
             self.create_calendar_frame,
             textvariable=self.create_calendar_color_var,
-            values=[""] + [str(i) for i in range(1, 25)],
+            values=list(CALENDAR_COLORS.values()),
             state="readonly",
-            width=10
+            width=20
         )
-        color_combo.grid(row=row, column=1, sticky=tk.W, padx=5, pady=5)
+        color_combo.grid(row=1, column=1, sticky=tk.W, padx=5, pady=5)
 
-        # Delete Calendar Frame
-        self.delete_calendar_frame = ttk.LabelFrame(scrollable, text="Delete Calendar", padding="10")
-
-        row = 0
-        ttk.Label(self.delete_calendar_frame, text="Calendar Owner:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
-        self.delete_calendar_owner_combo = ttk.Combobox(self.delete_calendar_frame, width=40)
-        self.delete_calendar_owner_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
-        self.delete_calendar_frame.columnconfigure(1, weight=1)
-
-        ttk.Button(
-            self.delete_calendar_frame,
-            text="Load Users",
-            command=self.load_users_for_delete_calendar
-        ).grid(row=row, column=2, padx=5, pady=5)
-
-        row += 1
-        ttk.Label(self.delete_calendar_frame, text="Calendar ID:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
-        self.delete_calendar_id_combo = ttk.Combobox(self.delete_calendar_frame, width=40)
-        self.delete_calendar_id_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
-
-        ttk.Button(
-            self.delete_calendar_frame,
-            text="Load Calendars",
-            command=self.load_calendars_for_delete
-        ).grid(row=row, column=2, padx=5, pady=5)
+        # Progress frame
+        self.manage_calendar_progress_frame = self.create_progress_frame(tab)
+        self.manage_calendar_progress_frame.pack(fill=tk.BOTH, expand=True, pady=(10, 0))
 
         # Execute button
-        execute_frame = ttk.Frame(scrollable)
-        execute_frame.pack(fill=tk.X, padx=10, pady=10)
+        execute_frame = ttk.Frame(tab)
+        execute_frame.pack(fill=tk.X, pady=(10, 0))
 
         ttk.Button(
             execute_frame,
             text="Execute",
             command=self.execute_manage_calendar_operation,
             width=20
-        ).pack(side=tk.LEFT, padx=5)
-
-        # Progress frame
-        self.manage_calendar_progress_frame = self.create_progress_frame(scrollable)
+        ).pack(side=tk.LEFT)
 
         # Initial state
         self.toggle_manage_calendar_operation()
 
     def toggle_manage_calendar_operation(self):
-        """Toggle between create and delete frames."""
+        """Toggle between create and delete modes."""
         if self.manage_calendar_operation_var.get() == "create":
-            self.delete_calendar_frame.pack_forget()
-            self.create_calendar_frame.pack(fill=tk.X, padx=10, pady=5)
+            # Create mode: hide load button, show create-specific fields, allow typing
+            self.manage_calendar_load_btn.grid_remove()
+            self.create_calendar_frame.grid()
+            self.manage_calendar_name_combo.config(state='normal')
         else:
-            self.create_calendar_frame.pack_forget()
-            self.delete_calendar_frame.pack(fill=tk.X, padx=10, pady=5)
+            # Delete mode: show load button, hide create-specific fields, make combobox readonly
+            self.manage_calendar_load_btn.grid()
+            self.create_calendar_frame.grid_remove()
+            self.manage_calendar_name_combo.config(state='readonly')
 
-    def load_users_for_create_calendar(self):
-        """Load users for create calendar owner."""
-        self.load_combobox_async(self.create_calendar_owner_combo, fetch_users, enable_fuzzy=True)
-
-    def load_users_for_delete_calendar(self):
-        """Load users for delete calendar owner."""
-        self.load_combobox_async(self.delete_calendar_owner_combo, fetch_users, enable_fuzzy=True)
-
-    def load_calendars_for_delete(self):
-        """Load calendars for deletion."""
-        owner_email = self.delete_calendar_owner_combo.get().strip()
+    def load_calendars_for_manage(self):
+        """Load calendars for selected owner."""
+        owner_email = self.manage_calendar_owner_combo.get().strip()
         if not owner_email:
             messagebox.showwarning("Warning", "Please enter calendar owner email first")
             return
@@ -416,26 +416,34 @@ class CalendarWindow(BaseOperationWindow):
             calendars = calendar_ops.get_user_calendars(owner_email)
             return [f"{cal['summary']} ({cal['id']})" for cal in calendars]
 
-        self.load_combobox_async(self.delete_calendar_id_combo, fetch_calendars, enable_fuzzy=True)
+        self.load_combobox_async(self.manage_calendar_name_combo, fetch_calendars, enable_fuzzy=True)
 
     def execute_manage_calendar_operation(self):
         """Execute create or delete calendar operation."""
         operation = self.manage_calendar_operation_var.get()
+        owner = self.manage_calendar_owner_combo.get().strip()
+        calendar_input = self.manage_calendar_name_combo.get().strip()
+
+        # Validate common fields
+        if not owner:
+            messagebox.showerror("Error", "Please enter calendar owner email")
+            return
+        if not calendar_input:
+            messagebox.showerror("Error", "Please enter calendar name")
+            return
 
         if operation == "create":
-            # Get create values
-            owner = self.create_calendar_owner_combo.get().strip()
-            name = self.create_calendar_name_entry.get().strip()
+            # Create mode
+            name = calendar_input
             description = self.create_calendar_desc_entry.get().strip()
-            color = self.create_calendar_color_var.get()
+            color_name = self.create_calendar_color_var.get()
 
-            # Validate
-            if not owner:
-                messagebox.showerror("Error", "Please enter calendar owner email")
-                return
-            if not name:
-                messagebox.showerror("Error", "Please enter calendar name")
-                return
+            # Get color ID from name
+            color_id = None
+            for cid, cname in CALENDAR_COLORS.items():
+                if cname == color_name and cid:
+                    color_id = cid
+                    break
 
             # Confirm
             if not messagebox.askyesno("Confirm", f"Create calendar '{name}' for {owner}?"):
@@ -449,23 +457,11 @@ class CalendarWindow(BaseOperationWindow):
                 owner,
                 name,
                 description,
-                color if color else None
+                color_id
             )
 
-        else:  # delete
-            # Get delete values
-            owner = self.delete_calendar_owner_combo.get().strip()
-            calendar_input = self.delete_calendar_id_combo.get().strip()
-
-            # Validate
-            if not owner:
-                messagebox.showerror("Error", "Please enter calendar owner email")
-                return
-            if not calendar_input:
-                messagebox.showerror("Error", "Please enter calendar ID")
-                return
-
-            # Extract calendar ID
+        else:
+            # Delete mode - extract calendar ID
             if '(' in calendar_input and calendar_input.endswith(')'):
                 calendar_id = calendar_input.split('(')[-1].rstrip(')')
             else:
@@ -488,16 +484,20 @@ class CalendarWindow(BaseOperationWindow):
 
     def create_view_info_tab(self):
         """Create tab for viewing calendar information."""
-        tab = ttk.Frame(self.notebook)
+        tab = ttk.Frame(self.notebook, padding="10")
         self.notebook.add(tab, text="View Calendar Info")
 
-        # Create scrollable container
-        container, scrollable = self.create_scrollable_frame(tab)
-        container.pack(fill=tk.BOTH, expand=True)
+        # Instructions
+        instructions = ttk.Label(
+            tab,
+            text="View calendar information, URLs, and permissions.",
+            wraplength=800
+        )
+        instructions.pack(pady=(0, 10), anchor=tk.W)
 
         # Calendar Selection Frame
-        selection_frame = ttk.LabelFrame(scrollable, text="Calendar Selection", padding="10")
-        selection_frame.pack(fill=tk.X, padx=10, pady=5)
+        selection_frame = ttk.LabelFrame(tab, text="Calendar Selection", padding="10")
+        selection_frame.pack(fill=tk.X, pady=(0, 10))
 
         row = 0
         ttk.Label(selection_frame, text="Calendar Owner:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
@@ -505,14 +505,8 @@ class CalendarWindow(BaseOperationWindow):
         self.view_info_owner_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
         selection_frame.columnconfigure(1, weight=1)
 
-        ttk.Button(
-            selection_frame,
-            text="Load Users",
-            command=self.load_users_for_view_info
-        ).grid(row=row, column=2, padx=5, pady=5)
-
         row += 1
-        ttk.Label(selection_frame, text="Calendar ID:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
+        ttk.Label(selection_frame, text="Calendar Name:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
         self.view_info_calendar_combo = ttk.Combobox(selection_frame, width=40)
         self.view_info_calendar_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
 
@@ -523,45 +517,33 @@ class CalendarWindow(BaseOperationWindow):
         ).grid(row=row, column=2, padx=5, pady=5)
 
         # Buttons Frame
-        buttons_frame = ttk.Frame(scrollable)
-        buttons_frame.pack(fill=tk.X, padx=10, pady=10)
+        buttons_frame = ttk.Frame(tab)
+        buttons_frame.pack(fill=tk.X, pady=(0, 10))
 
         ttk.Button(
             buttons_frame,
             text="View Calendar Info",
             command=self.view_calendar_info,
             width=20
-        ).pack(side=tk.LEFT, padx=5)
+        ).pack(side=tk.LEFT, padx=(0, 5))
 
         ttk.Button(
             buttons_frame,
             text="View Permissions",
             command=self.view_calendar_permissions,
             width=20
-        ).pack(side=tk.LEFT, padx=5)
+        ).pack(side=tk.LEFT, padx=(0, 5))
 
         ttk.Button(
             buttons_frame,
             text="Clear",
-            command=self.clear_view_info_results,
+            command=lambda: self.clear_results(self.view_info_progress_frame),
             width=15
-        ).pack(side=tk.LEFT, padx=5)
+        ).pack(side=tk.LEFT)
 
-        # Results Frame
-        results_frame = ttk.LabelFrame(scrollable, text="Calendar Information", padding="10")
-        results_frame.pack(fill=tk.BOTH, expand=True, padx=10, pady=5)
-
-        self.view_info_text = scrolledtext.ScrolledText(
-            results_frame,
-            wrap=tk.WORD,
-            height=20,
-            font=('Courier', 10)
-        )
-        self.view_info_text.pack(fill=tk.BOTH, expand=True)
-
-    def load_users_for_view_info(self):
-        """Load users for view info."""
-        self.load_combobox_async(self.view_info_owner_combo, fetch_users, enable_fuzzy=True)
+        # Progress frame (repurposed as results display)
+        self.view_info_progress_frame = self.create_progress_frame(tab)
+        self.view_info_progress_frame.pack(fill=tk.BOTH, expand=True, pady=(10, 0))
 
     def load_calendars_for_view_info(self):
         """Load calendars for view info."""
@@ -585,7 +567,7 @@ class CalendarWindow(BaseOperationWindow):
             messagebox.showerror("Error", "Please enter calendar owner email")
             return
         if not calendar_input:
-            messagebox.showerror("Error", "Please enter calendar ID")
+            messagebox.showerror("Error", "Please enter calendar name")
             return
 
         # Extract calendar ID
@@ -594,49 +576,21 @@ class CalendarWindow(BaseOperationWindow):
         else:
             calendar_id = calendar_input
 
-        # Clear results
-        self.view_info_text.delete(1.0, tk.END)
-        self.view_info_text.insert(tk.END, f"Retrieving information for calendar {calendar_id}...\n\n")
-
-        # Run in thread
-        def fetch_info():
-            result_queue = queue.Queue()
-
-            def run():
-                try:
-                    for progress in calendar_ops.get_calendar_info(calendar_id, owner):
-                        result_queue.put(progress)
-                    result_queue.put({'status': 'done'})
-                except Exception as e:
-                    result_queue.put({'status': 'error', 'message': str(e)})
-
-            thread = threading.Thread(target=run, daemon=True)
-            thread.start()
-
-            def check_queue():
-                try:
-                    while True:
-                        progress = result_queue.get_nowait()
-                        if progress['status'] == 'done':
-                            return
-                        elif progress['status'] == 'success':
-                            self.view_info_text.delete(1.0, tk.END)
-                            self.view_info_text.insert(tk.END, progress.get('data', ''))
-                        elif progress['status'] == 'error':
-                            self.view_info_text.insert(tk.END, f"\nError: {progress['message']}\n")
-                except queue.Empty:
-                    self.after(100, check_queue)
-
-            check_queue()
-
-        fetch_info()
+        # Clear and run
+        self.clear_results(self.view_info_progress_frame)
+        self.run_async_operation(
+            self.view_info_progress_frame,
+            calendar_ops.get_calendar_info,
+            calendar_id,
+            owner
+        )
 
     def view_calendar_permissions(self):
         """View calendar permissions."""
         calendar_input = self.view_info_calendar_combo.get().strip()
 
         if not calendar_input:
-            messagebox.showerror("Error", "Please enter calendar ID")
+            messagebox.showerror("Error", "Please enter calendar name")
             return
 
         # Extract calendar ID
@@ -645,167 +599,153 @@ class CalendarWindow(BaseOperationWindow):
         else:
             calendar_id = calendar_input
 
-        # Clear results
-        self.view_info_text.delete(1.0, tk.END)
-        self.view_info_text.insert(tk.END, f"Retrieving permissions for calendar {calendar_id}...\n\n")
-
-        # Run in thread
-        def fetch_acl():
-            result_queue = queue.Queue()
-
-            def run():
-                try:
-                    for progress in calendar_ops.get_calendar_acl(calendar_id):
-                        result_queue.put(progress)
-                    result_queue.put({'status': 'done'})
-                except Exception as e:
-                    result_queue.put({'status': 'error', 'message': str(e)})
-
-            thread = threading.Thread(target=run, daemon=True)
-            thread.start()
-
-            def check_queue():
-                try:
-                    while True:
-                        progress = result_queue.get_nowait()
-                        if progress['status'] == 'done':
-                            return
-                        elif progress['status'] == 'success':
-                            self.view_info_text.delete(1.0, tk.END)
-                            self.view_info_text.insert(tk.END, progress.get('data', ''))
-                        elif progress['status'] == 'error':
-                            self.view_info_text.insert(tk.END, f"\nError: {progress['message']}\n")
-                except queue.Empty:
-                    self.after(100, check_queue)
-
-            check_queue()
-
-        fetch_acl()
-
-    def clear_view_info_results(self):
-        """Clear view info results."""
-        self.view_info_text.delete(1.0, tk.END)
+        # Clear and run
+        self.clear_results(self.view_info_progress_frame)
+        self.run_async_operation(
+            self.view_info_progress_frame,
+            calendar_ops.get_calendar_acl,
+            calendar_id
+        )
 
     # ==================== TAB 4: IMPORT/EXPORT ====================
 
     def create_import_export_tab(self):
         """Create tab for importing/exporting calendar data."""
-        tab = ttk.Frame(self.notebook)
+        tab = ttk.Frame(self.notebook, padding="10")
         self.notebook.add(tab, text="Import/Export")
 
-        # Create scrollable container
-        container, scrollable = self.create_scrollable_frame(tab)
-        container.pack(fill=tk.BOTH, expand=True)
+        # Instructions
+        instructions = ttk.Label(
+            tab,
+            text="Import events from .ics files or export events to CSV.",
+            wraplength=800
+        )
+        instructions.pack(pady=(0, 10), anchor=tk.W)
 
-        # Import Section
-        import_frame = ttk.LabelFrame(scrollable, text="Import Calendar (.ics file)", padding="10")
-        import_frame.pack(fill=tk.X, padx=10, pady=5)
+        # Operation type
+        operation_frame = ttk.LabelFrame(tab, text="Operation", padding="10")
+        operation_frame.pack(fill=tk.X, pady=(0, 10))
 
+        self.import_export_operation_var = tk.StringVar(value="import")
+        ttk.Radiobutton(
+            operation_frame,
+            text="Import Calendar",
+            variable=self.import_export_operation_var,
+            value="import",
+            command=self.toggle_import_export_operation
+        ).pack(side=tk.LEFT, padx=(0, 20))
+
+        ttk.Radiobutton(
+            operation_frame,
+            text="Export Calendar",
+            variable=self.import_export_operation_var,
+            value="export",
+            command=self.toggle_import_export_operation
+        ).pack(side=tk.LEFT)
+
+        # Shared Calendar Selection Frame
+        calendar_frame = ttk.LabelFrame(tab, text="Calendar Selection", padding="10")
+        calendar_frame.pack(fill=tk.X, pady=(0, 10))
+
+        # Calendar Owner (shared)
         row = 0
-        ttk.Label(import_frame, text="Calendar Owner:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
-        self.import_owner_combo = ttk.Combobox(import_frame, width=40)
-        self.import_owner_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
-        import_frame.columnconfigure(1, weight=1)
+        ttk.Label(calendar_frame, text="Calendar Owner:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
+        self.import_export_owner_combo = ttk.Combobox(calendar_frame, width=40)
+        self.import_export_owner_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
+        calendar_frame.columnconfigure(1, weight=1)
 
-        ttk.Button(
-            import_frame,
-            text="Load Users",
-            command=self.load_users_for_import
-        ).grid(row=row, column=2, padx=5, pady=5)
-
+        # Calendar Name (shared)
         row += 1
-        ttk.Label(import_frame, text="Target Calendar:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
-        self.import_calendar_combo = ttk.Combobox(import_frame, width=40)
-        self.import_calendar_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
+        ttk.Label(calendar_frame, text="Calendar Name:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
+        self.import_export_calendar_combo = ttk.Combobox(calendar_frame, width=40)
+        self.import_export_calendar_combo.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
 
         ttk.Button(
-            import_frame,
+            calendar_frame,
             text="Load Calendars",
-            command=self.load_calendars_for_import
+            command=self.load_calendars_for_import_export
         ).grid(row=row, column=2, padx=5, pady=5)
 
-        row += 1
-        ttk.Label(import_frame, text=".ics File:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
-        self.import_file_entry = ttk.Entry(import_frame, width=40)
-        self.import_file_entry.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
+        # Import-specific frame
+        self.import_frame = ttk.LabelFrame(tab, text="Import Settings", padding="10")
+
+        ttk.Label(self.import_frame, text=".ics File:").grid(row=0, column=0, sticky=tk.W, padx=5, pady=5)
+        self.import_file_entry = ttk.Entry(self.import_frame, width=40)
+        self.import_file_entry.grid(row=0, column=1, sticky=tk.EW, padx=5, pady=5)
+        self.import_frame.columnconfigure(1, weight=1)
 
         ttk.Button(
-            import_frame,
+            self.import_frame,
             text="Browse...",
             command=self.browse_import_file
-        ).grid(row=row, column=2, padx=5, pady=5)
+        ).grid(row=0, column=2, padx=5, pady=5)
 
-        row += 1
-        ttk.Button(
-            import_frame,
-            text="Import",
-            command=self.execute_import,
-            width=15
-        ).grid(row=row, column=1, sticky=tk.W, padx=5, pady=10)
+        # Export-specific frame
+        self.export_frame = ttk.LabelFrame(tab, text="Export Settings", padding="10")
 
-        # Export Section
-        export_frame = ttk.LabelFrame(scrollable, text="Export Calendar Events", padding="10")
-        export_frame.pack(fill=tk.X, padx=10, pady=5)
-
-        row = 0
-        ttk.Label(export_frame, text="Calendar ID:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
-        self.export_calendar_entry = ttk.Entry(export_frame, width=40)
-        self.export_calendar_entry.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
-        export_frame.columnconfigure(1, weight=1)
-
-        row += 1
-        ttk.Label(export_frame, text="Start Date:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
-        self.export_start_date_entry = ttk.Entry(export_frame, width=20)
-        self.export_start_date_entry.grid(row=row, column=1, sticky=tk.W, padx=5, pady=5)
-        # Set default to 30 days ago
+        ttk.Label(self.export_frame, text="Start Date:").grid(row=0, column=0, sticky=tk.W, padx=5, pady=5)
+        self.export_start_date_entry = ttk.Entry(self.export_frame, width=20)
+        self.export_start_date_entry.grid(row=0, column=1, sticky=tk.W, padx=5, pady=5)
         default_start = (datetime.now() - timedelta(days=30)).strftime('%Y-%m-%d')
         self.export_start_date_entry.insert(0, default_start)
 
-        ttk.Label(export_frame, text="(YYYY-MM-DD)", font=('Arial', 9), foreground='gray').grid(
-            row=row, column=2, sticky=tk.W, padx=5, pady=5
+        ttk.Label(self.export_frame, text="(YYYY-MM-DD)", font=('Arial', 9), foreground='gray').grid(
+            row=0, column=2, sticky=tk.W, padx=5, pady=5
         )
 
-        row += 1
-        ttk.Label(export_frame, text="End Date:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
-        self.export_end_date_entry = ttk.Entry(export_frame, width=20)
-        self.export_end_date_entry.grid(row=row, column=1, sticky=tk.W, padx=5, pady=5)
-        # Set default to 30 days from now
+        ttk.Label(self.export_frame, text="End Date:").grid(row=1, column=0, sticky=tk.W, padx=5, pady=5)
+        self.export_end_date_entry = ttk.Entry(self.export_frame, width=20)
+        self.export_end_date_entry.grid(row=1, column=1, sticky=tk.W, padx=5, pady=5)
         default_end = (datetime.now() + timedelta(days=30)).strftime('%Y-%m-%d')
         self.export_end_date_entry.insert(0, default_end)
 
-        ttk.Label(export_frame, text="(YYYY-MM-DD)", font=('Arial', 9), foreground='gray').grid(
-            row=row, column=2, sticky=tk.W, padx=5, pady=5
+        ttk.Label(self.export_frame, text="(YYYY-MM-DD)", font=('Arial', 9), foreground='gray').grid(
+            row=1, column=2, sticky=tk.W, padx=5, pady=5
         )
 
-        row += 1
-        ttk.Label(export_frame, text="Output File:").grid(row=row, column=0, sticky=tk.W, padx=5, pady=5)
-        self.export_file_entry = ttk.Entry(export_frame, width=40)
-        self.export_file_entry.grid(row=row, column=1, sticky=tk.EW, padx=5, pady=5)
+        ttk.Label(self.export_frame, text="Output File:").grid(row=2, column=0, sticky=tk.W, padx=5, pady=5)
+        self.export_file_entry = ttk.Entry(self.export_frame, width=40)
+        self.export_file_entry.grid(row=2, column=1, sticky=tk.EW, padx=5, pady=5)
+        self.export_frame.columnconfigure(1, weight=1)
 
         ttk.Button(
-            export_frame,
+            self.export_frame,
             text="Browse...",
             command=self.browse_export_file
-        ).grid(row=row, column=2, padx=5, pady=5)
-
-        row += 1
-        ttk.Button(
-            export_frame,
-            text="Export",
-            command=self.execute_export,
-            width=15
-        ).grid(row=row, column=1, sticky=tk.W, padx=5, pady=10)
+        ).grid(row=2, column=2, padx=5, pady=5)
 
         # Progress frame
-        self.import_export_progress_frame = self.create_progress_frame(scrollable)
+        self.import_export_progress_frame = self.create_progress_frame(tab)
+        self.import_export_progress_frame.pack(fill=tk.BOTH, expand=True, pady=(10, 0))
 
-    def load_users_for_import(self):
-        """Load users for import."""
-        self.load_combobox_async(self.import_owner_combo, fetch_users, enable_fuzzy=True)
+        # Execute button
+        execute_frame = ttk.Frame(tab)
+        execute_frame.pack(fill=tk.X, pady=(10, 0))
 
-    def load_calendars_for_import(self):
-        """Load calendars for import."""
-        owner_email = self.import_owner_combo.get().strip()
+        ttk.Button(
+            execute_frame,
+            text="Execute",
+            command=self.execute_import_export_operation,
+            width=20
+        ).pack(side=tk.LEFT)
+
+        # Initial state
+        self.toggle_import_export_operation()
+
+    def toggle_import_export_operation(self):
+        """Toggle between import and export modes."""
+        if self.import_export_operation_var.get() == "import":
+            # Import mode
+            self.export_frame.pack_forget()
+            self.import_frame.pack(fill=tk.X, pady=(0, 10))
+        else:
+            # Export mode
+            self.import_frame.pack_forget()
+            self.export_frame.pack(fill=tk.X, pady=(0, 10))
+
+    def load_calendars_for_import_export(self):
+        """Load calendars for import/export."""
+        owner_email = self.import_export_owner_combo.get().strip()
         if not owner_email:
             messagebox.showwarning("Warning", "Please enter calendar owner email first")
             return
@@ -814,7 +754,7 @@ class CalendarWindow(BaseOperationWindow):
             calendars = calendar_ops.get_user_calendars(owner_email)
             return [f"{cal['summary']} ({cal['id']})" for cal in calendars]
 
-        self.load_combobox_async(self.import_calendar_combo, fetch_calendars, enable_fuzzy=True)
+        self.load_combobox_async(self.import_export_calendar_combo, fetch_calendars, enable_fuzzy=True)
 
     def browse_import_file(self):
         """Browse for import .ics file."""
@@ -837,25 +777,18 @@ class CalendarWindow(BaseOperationWindow):
             self.export_file_entry.delete(0, tk.END)
             self.export_file_entry.insert(0, file_path)
 
-    def execute_import(self):
-        """Execute calendar import."""
-        owner = self.import_owner_combo.get().strip()
-        calendar_input = self.import_calendar_combo.get().strip()
-        ics_file = self.import_file_entry.get().strip()
+    def execute_import_export_operation(self):
+        """Execute import or export operation."""
+        operation = self.import_export_operation_var.get()
+        owner = self.import_export_owner_combo.get().strip()
+        calendar_input = self.import_export_calendar_combo.get().strip()
 
-        # Validate
+        # Validate common fields
         if not owner:
             messagebox.showerror("Error", "Please enter calendar owner email")
             return
         if not calendar_input:
-            messagebox.showerror("Error", "Please select target calendar")
-            return
-        if not ics_file:
-            messagebox.showerror("Error", "Please select .ics file")
-            return
-
-        if not os.path.exists(ics_file):
-            messagebox.showerror("Error", f"File not found: {ics_file}")
+            messagebox.showerror("Error", "Please select calendar")
             return
 
         # Extract calendar ID
@@ -864,57 +797,64 @@ class CalendarWindow(BaseOperationWindow):
         else:
             calendar_id = calendar_input
 
-        # Confirm
-        if not messagebox.askyesno("Confirm", f"Import events from {os.path.basename(ics_file)} to calendar {calendar_id}?"):
-            return
+        if operation == "import":
+            # Import operation
+            ics_file = self.import_file_entry.get().strip()
 
-        # Clear and execute
-        self.clear_results(self.import_export_progress_frame)
-        self.run_async_operation(
-            self.import_export_progress_frame,
-            calendar_ops.import_calendar,
-            owner,
-            calendar_id,
-            ics_file
-        )
+            if not ics_file:
+                messagebox.showerror("Error", "Please select .ics file")
+                return
 
-    def execute_export(self):
-        """Execute calendar export."""
-        calendar_id = self.export_calendar_entry.get().strip()
-        start_date = self.export_start_date_entry.get().strip()
-        end_date = self.export_end_date_entry.get().strip()
-        output_file = self.export_file_entry.get().strip()
+            if not os.path.exists(ics_file):
+                messagebox.showerror("Error", f"File not found: {ics_file}")
+                return
 
-        # Validate
-        if not calendar_id:
-            messagebox.showerror("Error", "Please enter calendar ID")
-            return
-        if not start_date or not end_date:
-            messagebox.showerror("Error", "Please enter date range")
-            return
-        if not output_file:
-            messagebox.showerror("Error", "Please select output file")
-            return
+            # Confirm
+            if not messagebox.askyesno("Confirm", f"Import events from {os.path.basename(ics_file)} to calendar {calendar_id}?"):
+                return
 
-        # Validate date format (basic)
-        try:
-            datetime.strptime(start_date, '%Y-%m-%d')
-            datetime.strptime(end_date, '%Y-%m-%d')
-        except ValueError:
-            messagebox.showerror("Error", "Invalid date format. Use YYYY-MM-DD")
-            return
+            # Clear and execute
+            self.clear_results(self.import_export_progress_frame)
+            self.run_async_operation(
+                self.import_export_progress_frame,
+                calendar_ops.import_calendar,
+                owner,
+                calendar_id,
+                ics_file
+            )
 
-        # Confirm
-        if not messagebox.askyesno("Confirm", f"Export events from {start_date} to {end_date}?"):
-            return
+        else:
+            # Export operation
+            start_date = self.export_start_date_entry.get().strip()
+            end_date = self.export_end_date_entry.get().strip()
+            output_file = self.export_file_entry.get().strip()
 
-        # Clear and execute
-        self.clear_results(self.import_export_progress_frame)
-        self.run_async_operation(
-            self.import_export_progress_frame,
-            calendar_ops.export_calendar_events,
-            calendar_id,
-            start_date,
-            end_date,
-            output_file
-        )
+            if not start_date or not end_date:
+                messagebox.showerror("Error", "Please enter date range")
+                return
+            if not output_file:
+                messagebox.showerror("Error", "Please select output file")
+                return
+
+            # Validate date format
+            try:
+                datetime.strptime(start_date, '%Y-%m-%d')
+                datetime.strptime(end_date, '%Y-%m-%d')
+            except ValueError:
+                messagebox.showerror("Error", "Invalid date format. Use YYYY-MM-DD")
+                return
+
+            # Confirm
+            if not messagebox.askyesno("Confirm", f"Export events from {start_date} to {end_date}?"):
+                return
+
+            # Clear and execute
+            self.clear_results(self.import_export_progress_frame)
+            self.run_async_operation(
+                self.import_export_progress_frame,
+                calendar_ops.export_calendar_events,
+                calendar_id,
+                start_date,
+                end_date,
+                output_file
+            )


### PR DESCRIPTION
Complete rewrite of calendar operations window to follow established patterns from email/users/groups windows.

Key Changes:
1. Removed scrollable frames - using regular ttk.Frame with padding
2. Added initialize_comboboxes() to auto-load all user comboboxes
3. Removed all "Load Users" buttons (except dependent "Load Calendars")
4. Added progress frames (command log) to all 4 tabs
5. Moved execute buttons below progress frames

Tab 1: Manage Permissions
- Auto-load Calendar Owner and User/Group Email comboboxes
- Keep "Load Calendars" button (depends on owner selection)
- Changed "Calendar ID" to "Calendar Name"
- Added fuzzy search to all comboboxes
- Added progress frame with results display

Tab 2: Create/Delete Calendars
- Restructured with radio buttons and shared fields
- Single "Calendar Owner" field for both modes
- Single "Calendar Name" field (readonly in delete, editable in create)
- Color dropdown now shows color names instead of numbers
- "Load Calendars" button only visible in delete mode
- Description and Color fields only visible in create mode
- Added progress frame with results display

Tab 3: View Calendar Info
- Auto-load Calendar Owner combobox
- Changed "Calendar ID" to "Calendar Name"
- Fixed empty calendar_id bug (now passes calendar_id correctly)
- Uses progress frame instead of custom text widget
- Both "View Calendar Info" and "View Permissions" now work

Tab 4: Import/Export
- Restructured with radio buttons and shared fields
- Single "Calendar Owner" field for both modes
- Single "Calendar Name" field for both modes
- Import/Export specific fields toggle based on radio selection
- Added progress frame with results display

Additional Improvements:
- Added CALENDAR_COLORS dict mapping color IDs to names
- All tabs follow consistent layout patterns
- Instructions at top of each tab
- Execute buttons consistently positioned
- Proper use of LabelFrames for grouping
- Consistent padding and spacing

Bug Fixes:
- Fixed View Calendar Info empty calendar_id error
- Fixed View Permissions not displaying anything
- All operations now properly display results in progress frame