### PR TITLE
Fix: Calendar loading now works - use calendarId field

### DIFF
--- a/gui/calendar_window.py
+++ b/gui/calendar_window.py
@@ -228,12 +228,8 @@ class CalendarWindow(BaseOperationWindow):
             return
 
         def fetch_calendars():
-            print(f"DEBUG: Fetching calendars for {owner_email}")
             calendars = calendar_ops.get_user_calendars(owner_email)
-            print(f"DEBUG: Got {len(calendars)} calendars")
-            formatted = [f"{cal['summary']} ({cal['id']})" for cal in calendars if cal.get('id')]
-            print(f"DEBUG: Formatted to {len(formatted)} items: {formatted}")
-            return formatted
+            return [f"{cal['summary']} ({cal['id']})" for cal in calendars if cal.get('id')]
 
         self.load_combobox_async(self.permissions_calendar_combo, fetch_calendars, enable_fuzzy=True)
 
@@ -416,12 +412,8 @@ class CalendarWindow(BaseOperationWindow):
             return
 
         def fetch_calendars():
-            print(f"DEBUG: [Manage] Fetching calendars for {owner_email}")
             calendars = calendar_ops.get_user_calendars(owner_email)
-            print(f"DEBUG: [Manage] Got {len(calendars)} calendars")
-            formatted = [f"{cal['summary']} ({cal['id']})" for cal in calendars if cal.get('id')]
-            print(f"DEBUG: [Manage] Formatted to {len(formatted)} items")
-            return formatted
+            return [f"{cal['summary']} ({cal['id']})" for cal in calendars if cal.get('id')]
 
         self.load_combobox_async(self.manage_calendar_name_combo, fetch_calendars, enable_fuzzy=True)
 

--- a/modules/calendar.py
+++ b/modules/calendar.py
@@ -50,25 +50,16 @@ def get_user_calendars(user_email):
         calendars = []
         if result.stdout:
             log_info("Get User Calendars", f"Parsing calendar data for {user_email}")
-            # Debug: show first few lines of CSV output
-            print(f"DEBUG: CSV output (first 500 chars): {result.stdout[:500]}")
             reader = csv.DictReader(io.StringIO(result.stdout))
-            for i, row in enumerate(reader):
-                # Debug: print first row to see what fields we have
-                if i == 0:
-                    print(f"DEBUG: CSV headers: {list(row.keys())}")
-                    print(f"DEBUG: First calendar row: {dict(row)}")
-
+            for row in reader:
                 cal = {
-                    'id': row.get('id', ''),
+                    'id': row.get('calendarId', ''),  # GAM uses 'calendarId' not 'id'
                     'summary': row.get('summary', ''),
                     'accessRole': row.get('accessRole', '')
                 }
                 calendars.append(cal)
-                log_info("Get User Calendars", f"Found calendar: {cal['summary']} ({cal['id']})")
 
         log_info("Get User Calendars", f"Loaded {len(calendars)} calendars for {user_email}")
-        print(f"DEBUG: Returning {len(calendars)} calendars")
         return calendars
 
     except Exception as e:


### PR DESCRIPTION
Critical fix for calendar dropdown loading:
- Changed field name from 'id' to 'calendarId' to match GAM CSV output
- Removed debug logging after identifying the issue
- Calendars will now populate correctly in all dropdown menus

Root cause: GAM's CSV output uses 'calendarId' as the column name, not 'id'. The filtering logic was checking for cal.get('id') which always returned empty string.