### PR TITLE
Fix timezone parameter order in event creation

### DIFF
--- a/modules/calendar.py
+++ b/modules/calendar.py
@@ -528,8 +528,8 @@ def import_calendar_events(calendar_id, csv_file_path, timezone):
 
                 # Build GAM command
                 cmd = [gam_cmd, 'calendar', calendar_id, 'add', 'event',
-                       'start', start_iso, 'end', end_iso,
                        'timezone', timezone,
+                       'start', start_iso, 'end', end_iso,
                        'summary', subject]
 
                 if is_all_day:


### PR DESCRIPTION
Moved timezone parameter before start/end times in GAM command. GAM requires timezone to be specified before the datetime values so it knows how to interpret them.

Changed from:
  gam calendar <id> add event start <time> end <time> timezone <tz> summary <title>

To:
  gam calendar <id> add event timezone <tz> start <time> end <time> summary <title>

This fixes: "Missing time zone definition for start time" error