### PR TITLE
Fix issues #39, #42, #43: fuzzy search focus on Windows, admin audit …

### DIFF
--- a/gui/base_operation_window.py
+++ b/gui/base_operation_window.py
@@ -1042,11 +1042,13 @@ class BaseOperationWindow(tk.Toplevel, ABC):
             # Update combobox with filtered values
             combobox['values'] = filtered
 
-            # Open dropdown if there are matches, but keep focus on entry
+            # Open dropdown if there are matches, but keep focus on entry.
+            # Use after(1, ...) to defer focus restoration — needed on Windows
+            # where event_generate('<Down>') processes asynchronously and
+            # calling focus_set() inline loses the race.
             if filtered and not event.keysym in ('Up', 'Down', 'Return', 'Escape'):
                 combobox.event_generate('<Down>')
-                # Immediately restore focus to the entry field
-                combobox.focus_set()
+                combobox.after(1, combobox.focus_set)
 
         # Bind the keyrelease event
         combobox.bind('<KeyRelease>', on_keyrelease)
@@ -1651,7 +1653,7 @@ class BaseOperationWindow(tk.Toplevel, ABC):
             # Show dropdown if there are matches
             if filtered:
                 combobox.event_generate('<Down>')
-                combobox.focus_set()  # Keep focus on text entry
+                combobox.after(1, combobox.focus_set)
 
         # Bind the event
         combobox.bind('<KeyRelease>', on_keyrelease)

--- a/gui/reports_window.py
+++ b/gui/reports_window.py
@@ -1,73 +1,223 @@
 """
 Reports window for GAM Admin Tool.
 
-This module is under development.
+Provides a tabbed interface for audit and usage reports:
+- Admin Audit: activity log with optional event-type filtering (#42)
+- Email Usage: per-user gmail statistics (#43)
 """
 
 import tkinter as tk
-from tkinter import ttk
+from tkinter import ttk, messagebox
+import threading
+from datetime import date, timedelta
+
+from gui.base_operation_window import BaseOperationWindow
+from modules.reports import ADMIN_EVENT_TYPES, fetch_admin_audit, fetch_email_usage
+from utils.workspace_data import fetch_users
 
 
-class ReportsWindow(tk.Toplevel):
-    """
-    Reports window (placeholder).
-
-    This window will be implemented in a future release.
-    """
+class ReportsWindow(BaseOperationWindow):
+    """Reports window with Admin Audit and Email Usage tabs."""
 
     def __init__(self, parent):
-        """
-        Initialize the Reports window.
+        super().__init__(parent, "Reports", "900x700", (700, 500))
 
-        Args:
-            parent: The parent tkinter widget
-        """
-        super().__init__(parent)
+    def create_operation_tabs(self):
+        """Create all report tabs."""
+        self._create_admin_audit_tab()
+        self._create_email_usage_tab()
 
-        self.title("Reports")
-        self.geometry("500x300")
+    # ==================== TAB 1: ADMIN AUDIT ====================
 
-        # Center the window
-        self.transient(parent)
-        self.grab_set()
+    def _create_admin_audit_tab(self):
+        tab = ttk.Frame(self.notebook, padding="10")
+        self.notebook.add(tab, text="Admin Audit")
 
-        # Create widgets
-        self.create_widgets()
+        ttk.Label(
+            tab,
+            text="Pull admin activity logs. Filter by event type and/or date range.",
+            wraplength=800
+        ).pack(pady=(0, 10), anchor=tk.W)
 
-        # Center on screen
-        self.update_idletasks()
-        x = (self.winfo_screenwidth() // 2) - (self.winfo_width() // 2)
-        y = (self.winfo_screenheight() // 2) - (self.winfo_height() // 2)
-        self.geometry(f'+{x}+{y}')
+        # --- Filters ---
+        filters_frame = ttk.LabelFrame(tab, text="Filters", padding="10")
+        filters_frame.pack(fill=tk.X, pady=(0, 10))
+        filters_frame.columnconfigure(1, weight=1)
 
-    def create_widgets(self):
-        """Create and layout widgets."""
-        # Main container
-        container = ttk.Frame(self, padding="40")
-        container.pack(fill=tk.BOTH, expand=True)
-
-        # Icon or placeholder
-        icon_label = ttk.Label(
-            container,
-            text="🚧",
-            font=('Arial', 48)
+        # Event type
+        ttk.Label(filters_frame, text="Event Type:").grid(row=0, column=0, sticky=tk.W, padx=5, pady=5)
+        self._audit_event_var = tk.StringVar(value="All Events")
+        event_combo = ttk.Combobox(
+            filters_frame,
+            textvariable=self._audit_event_var,
+            values=ADMIN_EVENT_TYPES,
+            state="readonly",
+            width=35
         )
-        icon_label.pack(pady=(0, 20))
+        event_combo.grid(row=0, column=1, sticky=tk.W, padx=5, pady=5)
 
-        # Message
-        message_label = ttk.Label(
-            container,
-            text="This module is under development.\nCheck back in a future release!",
-            font=('Arial', 12),
-            justify=tk.CENTER
+        # Start date
+        ttk.Label(filters_frame, text="Start Date (YYYY-MM-DD):").grid(row=1, column=0, sticky=tk.W, padx=5, pady=5)
+        self._audit_start_var = tk.StringVar()
+        ttk.Entry(filters_frame, textvariable=self._audit_start_var, width=20).grid(
+            row=1, column=1, sticky=tk.W, padx=5, pady=5
         )
-        message_label.pack(pady=20)
+        ttk.Label(filters_frame, text="(optional)", foreground="gray").grid(row=1, column=2, sticky=tk.W)
 
-        # Close button
-        close_button = ttk.Button(
-            container,
-            text="Close",
-            command=self.destroy,
-            width=15
+        # End date
+        ttk.Label(filters_frame, text="End Date (YYYY-MM-DD):").grid(row=2, column=0, sticky=tk.W, padx=5, pady=5)
+        self._audit_end_var = tk.StringVar()
+        ttk.Entry(filters_frame, textvariable=self._audit_end_var, width=20).grid(
+            row=2, column=1, sticky=tk.W, padx=5, pady=5
         )
-        close_button.pack(pady=20)
+        ttk.Label(filters_frame, text="(optional)", foreground="gray").grid(row=2, column=2, sticky=tk.W)
+
+        # --- Run button ---
+        ttk.Button(
+            tab,
+            text="Run Admin Audit",
+            command=self._run_admin_audit
+        ).pack(pady=(0, 10))
+
+        # --- Output area ---
+        output_frame = ttk.LabelFrame(tab, text="Output", padding="5")
+        output_frame.pack(fill=tk.BOTH, expand=True)
+
+        self._audit_output = tk.Text(output_frame, wrap=tk.NONE, height=18, font=("Courier", 9))
+        vsb = ttk.Scrollbar(output_frame, orient=tk.VERTICAL, command=self._audit_output.yview)
+        hsb = ttk.Scrollbar(output_frame, orient=tk.HORIZONTAL, command=self._audit_output.xview)
+        self._audit_output.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+
+        hsb.pack(side=tk.BOTTOM, fill=tk.X)
+        vsb.pack(side=tk.RIGHT, fill=tk.Y)
+        self._audit_output.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+    def _run_admin_audit(self):
+        event_type = self._audit_event_var.get().strip()
+        start_date = self._audit_start_var.get().strip() or None
+        end_date = self._audit_end_var.get().strip() or None
+
+        self._audit_output.delete("1.0", tk.END)
+        self._audit_output.insert(tk.END, "Running admin audit...\n")
+
+        def run():
+            result = fetch_admin_audit(
+                start_date=start_date,
+                end_date=end_date,
+                event_type=event_type if event_type != "All Events" else None
+            )
+            self.after(0, lambda: self._display_audit_result(result))
+
+        threading.Thread(target=run, daemon=True).start()
+
+    def _display_audit_result(self, result):
+        self._audit_output.delete("1.0", tk.END)
+        if result["success"]:
+            output = result["output"].strip()
+            self._audit_output.insert(tk.END, output if output else "(No results returned)")
+        else:
+            self._audit_output.insert(tk.END, f"ERROR:\n{result['error']}")
+
+    # ==================== TAB 2: EMAIL USAGE ====================
+
+    def _create_email_usage_tab(self):
+        tab = ttk.Frame(self.notebook, padding="10")
+        self.notebook.add(tab, text="Email Usage")
+
+        ttk.Label(
+            tab,
+            text="Fetch email usage statistics for a specific user.",
+            wraplength=800
+        ).pack(pady=(0, 10), anchor=tk.W)
+
+        # --- Parameters ---
+        params_frame = ttk.LabelFrame(tab, text="Parameters", padding="10")
+        params_frame.pack(fill=tk.X, pady=(0, 10))
+        params_frame.columnconfigure(1, weight=1)
+
+        # User email
+        ttk.Label(params_frame, text="User Email:").grid(row=0, column=0, sticky=tk.W, padx=5, pady=5)
+        self._usage_user_combo = ttk.Combobox(params_frame, width=40)
+        self._usage_user_combo.grid(row=0, column=1, sticky=tk.EW, padx=5, pady=5)
+
+        # Date
+        ttk.Label(params_frame, text="Date (YYYY-MM-DD):").grid(row=1, column=0, sticky=tk.W, padx=5, pady=5)
+        default_date = (date.today() - timedelta(days=1)).strftime("%Y-%m-%d")
+        self._usage_date_var = tk.StringVar(value=default_date)
+        ttk.Entry(params_frame, textvariable=self._usage_date_var, width=20).grid(
+            row=1, column=1, sticky=tk.W, padx=5, pady=5
+        )
+        ttk.Label(
+            params_frame,
+            text="(usage data is typically available with a 1-2 day delay)",
+            foreground="gray", font=("Arial", 9)
+        ).grid(row=1, column=2, sticky=tk.W, padx=5)
+
+        # Parameters field
+        ttk.Label(params_frame, text="Parameters:").grid(row=2, column=0, sticky=tk.W, padx=5, pady=5)
+        self._usage_params_var = tk.StringVar(
+            value="gmail:num_emails_sent,gmail:num_emails_received"
+        )
+        ttk.Entry(params_frame, textvariable=self._usage_params_var, width=60).grid(
+            row=2, column=1, columnspan=2, sticky=tk.EW, padx=5, pady=5
+        )
+        ttk.Label(
+            params_frame,
+            text="Comma-separated gmail parameters (leave blank for all)",
+            foreground="gray", font=("Arial", 9)
+        ).grid(row=3, column=1, columnspan=2, sticky=tk.W, padx=5)
+
+        # --- Run button ---
+        ttk.Button(
+            tab,
+            text="Fetch Email Usage",
+            command=self._run_email_usage
+        ).pack(pady=(0, 10))
+
+        # --- Output area ---
+        output_frame = ttk.LabelFrame(tab, text="Output", padding="5")
+        output_frame.pack(fill=tk.BOTH, expand=True)
+
+        self._usage_output = tk.Text(output_frame, wrap=tk.NONE, height=18, font=("Courier", 9))
+        vsb = ttk.Scrollbar(output_frame, orient=tk.VERTICAL, command=self._usage_output.yview)
+        hsb = ttk.Scrollbar(output_frame, orient=tk.HORIZONTAL, command=self._usage_output.xview)
+        self._usage_output.configure(yscrollcommand=vsb.set, xscrollcommand=hsb.set)
+
+        hsb.pack(side=tk.BOTTOM, fill=tk.X)
+        vsb.pack(side=tk.RIGHT, fill=tk.Y)
+        self._usage_output.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        # Load users into combobox
+        self.after(100, lambda: self.load_combobox_async(
+            self._usage_user_combo, fetch_users, enable_fuzzy=True
+        ))
+
+    def _run_email_usage(self):
+        user_email = self._usage_user_combo.get().strip()
+        if not user_email:
+            messagebox.showwarning("Missing Input", "Please enter or select a user email.")
+            return
+
+        report_date = self._usage_date_var.get().strip() or None
+        parameters = self._usage_params_var.get().strip() or None
+
+        self._usage_output.delete("1.0", tk.END)
+        self._usage_output.insert(tk.END, f"Fetching email usage statistics for {user_email}...\n")
+
+        def run():
+            result = fetch_email_usage(
+                user_email=user_email,
+                date=report_date,
+                parameters=parameters
+            )
+            self.after(0, lambda: self._display_usage_result(result))
+
+        threading.Thread(target=run, daemon=True).start()
+
+    def _display_usage_result(self, result):
+        self._usage_output.delete("1.0", tk.END)
+        if result["success"]:
+            output = result["output"].strip()
+            self._usage_output.insert(tk.END, output if output else "(No data returned for this date)")
+        else:
+            self._usage_output.insert(tk.END, f"ERROR:\n{result['error']}")

--- a/modules/reports.py
+++ b/modules/reports.py
@@ -1,0 +1,122 @@
+"""
+Reports module for GAM Admin Tool.
+
+Provides backend functions for Google Workspace audit and usage reports:
+- Admin audit activity reports
+- Email usage reports (per-user)
+"""
+
+import subprocess
+from modules.base_operations import get_gam_command, execute_gam_command
+from utils.logger import log_error, log_info
+
+
+# Valid GAM admin audit event names.
+# These correspond to the Google Workspace Admin SDK activityName values
+# for the 'admin' application.  Passing any other string (e.g. "USER_SETTINGS")
+# causes GAM to return "Event X not found in manifest" (issue #42).
+ADMIN_EVENT_TYPES = [
+    "All Events",
+    "CHANGE_APPLICATION_SETTING",
+    "CREATE_USER",
+    "DELETE_USER",
+    "CHANGE_PASSWORD",
+    "RENAME_USER",
+    "SUSPEND_USER",
+    "UNSUSPEND_USER",
+    "CREATE_GROUP",
+    "DELETE_GROUP",
+    "ADD_TO_GROUP",
+    "REMOVE_FROM_GROUP",
+    "CHANGE_GROUP_SETTING",
+    "CREATE_ORG",
+    "DELETE_ORG",
+    "MOVE_ORG_USER",
+    "CREATE_ALIAS",
+    "DELETE_ALIAS",
+    "REVOKE_ASP",
+    "GENERATE_ASP",
+    "TOGGLE_SERVICE_ENABLED",
+    "CHANGE_DEVICE_POLICY",
+]
+
+
+def fetch_admin_audit(start_date=None, end_date=None, event_type=None):
+    """
+    Fetch admin audit activity report.
+
+    Args:
+        start_date (str, optional): Start date in YYYY-MM-DD format
+        end_date (str, optional): End date in YYYY-MM-DD format
+        event_type (str, optional): GAM admin event name, e.g. "CREATE_USER".
+            Pass None or "All Events" to return all event types.
+
+    Returns:
+        dict: {"output": str, "error": str, "success": bool}
+    """
+    gam_cmd = get_gam_command()
+    cmd = [gam_cmd, 'report', 'admin']
+
+    # Only add eventname when a specific type is requested — "All Events"
+    # (or None) means we omit the flag, which returns everything.
+    if event_type and event_type != "All Events":
+        cmd += ['eventname', event_type]
+
+    if start_date:
+        cmd += ['starttime', start_date]
+    if end_date:
+        cmd += ['endtime', end_date]
+
+    log_info("Admin Audit", f"Running: {' '.join(cmd)}")
+
+    try:
+        result = execute_gam_command(cmd, timeout=120, operation_name="Admin Audit")
+        if result.returncode != 0:
+            error_msg = result.stderr.strip() or result.stdout.strip()
+            log_error("Admin Audit", f"Command failed: {error_msg}")
+            return {"output": result.stdout, "error": error_msg, "success": False}
+        return {"output": result.stdout, "error": result.stderr, "success": True}
+    except Exception as e:
+        log_error("Admin Audit", f"Exception: {str(e)}")
+        return {"output": "", "error": str(e), "success": False}
+
+
+def fetch_email_usage(user_email, date=None, parameters=None):
+    """
+    Fetch email usage statistics for a specific user.
+
+    The correct GAM syntax is:
+        gam report usage user <email> [parameters <params>] [date <YYYY-MM-DD>]
+
+    NOT "gam user <email> report usage ..." (issue #43).
+
+    Args:
+        user_email (str): User's email address
+        date (str, optional): Date in YYYY-MM-DD format (most recent available
+            if omitted)
+        parameters (str, optional): Comma-separated gmail parameters, e.g.
+            "gmail:num_emails_sent,gmail:num_emails_received"
+
+    Returns:
+        dict: {"output": str, "error": str, "success": bool}
+    """
+    gam_cmd = get_gam_command()
+    cmd = [gam_cmd, 'report', 'usage', 'user', user_email]
+
+    if parameters:
+        cmd += ['parameters', parameters]
+    if date:
+        cmd += ['date', date]
+
+    log_info("Email Usage", f"Running: {' '.join(cmd)}")
+
+    try:
+        result = execute_gam_command(cmd, timeout=120, operation_name="Email Usage")
+        if result.returncode != 0:
+            error_msg = result.stderr.strip() or result.stdout.strip()
+            log_error("Email Usage", f"Command failed: {error_msg}")
+            return {"output": result.stdout, "error": error_msg, "success": False}
+        return {"output": result.stdout, "error": result.stderr, "success": True}
+    except Exception as e:
+        log_error("Email Usage", f"Exception: {str(e)}")
+        return {"output": "", "error": str(e), "success": False}


### PR DESCRIPTION
…event types, email usage command

- Fix #39: Defer combobox focus restoration with after(1, ...) in both enable_fuzzy_search() and _enable_standalone_fuzzy_search() so the focus_set() call wins the race on Windows where event_generate('<Down>') processes asynchronously.

- Fix #42: Replace the reports window stub with a functional Admin Audit tab that uses 'gam report admin [eventname X]' with a dropdown of valid GAM event names. Previously UI passed names like USER_SETTINGS which caused "Event X not found in manifest" errors.

- Fix #43: Implement Email Usage tab using the correct GAM command 'gam report usage user <email> parameters X date Y' instead of the broken 'gam user <email> report usage ...' syntax.

https://claude.ai/code/session_01QgpcKpeXEXRAEGSrPFyGxH